### PR TITLE
Add handler to restart ssh only if necessary. Fix #6

### DIFF
--- a/roles/ansible-ssh-hardening/handlers/main.yml
+++ b/roles/ansible-ssh-hardening/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart sshd
+  service: name={{ sshd_service_name }} state=restarted

--- a/roles/ansible-ssh-hardening/tasks/main.yml
+++ b/roles/ansible-ssh-hardening/tasks/main.yml
@@ -3,10 +3,8 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 - name: create sshd_config and set permissions to root/600
-  template: src='opensshd.conf.j2' dest='/etc/ssh/sshd_config' mode=0600 owner=root group=root
+  template: src='opensshd.conf.j2' dest='/etc/ssh/sshd_config' mode=0600 owner=root group=root validate="/usr/sbin/sshd -T -f %s"
+  notify: restart sshd
 
 - name: create ssh_config and set permissions to root/644
   template: src='openssh.conf.j2' dest='/etc/ssh/ssh_config' mode=0644 owner=root group=root
-
-- name: restart sshd
-  service: name={{ sshd_service_name }} state=restarted


### PR DESCRIPTION
You're right, thanks @chris-rock !

I also added a validation-feature, so if there are any errors in the sshd-configuration, it won't get copied to the host in the first place.

