### PR TITLE
Separate system-vars from editable vars

### DIFF
--- a/roles/ansible-ssh-hardening/defaults/main.yml
+++ b/roles/ansible-ssh-hardening/defaults/main.yml
@@ -1,0 +1,57 @@
+# true if IPv6 is needed
+network_ipv6_enable: false              # sshd + ssh
+
+# true if CBC for ciphers is required. This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure ciphers enabled. CBC is a weak alternative. Anything weaker should be avoided and is thus not available.
+ssh_client_cbc_required: false          # ssh
+ssh_server_cbc_required: false          # sshd
+
+# true if weaker HMAC mechanisms are required. This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure HMACs enabled.
+ssh_client_weak_hmac: false             # ssh
+ssh_server_weak_hmac: false             # sshd
+
+# true if weaker Key-Exchange (KEX) mechanisms are required. This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure KEXs enabled.
+ssh_client_weak_kex: false              # ssh
+ssh_server_weak_kex: false              # sshd
+
+# ports to which ssh-server should listen to and ssh-client should connect to
+ssh_ports: ['22']      # sshd + ssh
+
+# one or more ip addresses, to which ssh-server should listen to. Default is empty, but should be configured for security reasons!
+ssh_listen_to: ['0.0.0.0']    # sshd
+
+# Host keys to look for when starting sshd.
+ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key', '/etc/ssh/ssh_host_ecdsa_key']        # sshd
+
+ssh_client_alive_interval: 600          # sshd
+ssh_client_alive_count: 3               # sshd
+# one or more hosts, to which ssh-client can connect to. Default is empty, but should be configured for security reasons!
+ssh_remote_hosts: []           # ssh
+# false to disable root login altogether. Set to true to allow root to login via key-based mechanism.
+ssh_allow_root_with_key: false          # sshd
+
+# false to disable TCP Forwarding. Set to true to allow TCP Forwarding.
+ssh_allow_tcp_forwarding: false         # sshd
+
+# false to disable Agent Forwarding. Set to true to allow Agent Forwarding.
+ssh_allow_agent_forwarding: false       # sshd
+
+# false to disable pam authentication.
+ssh_use_pam: false      # sshd
+
+# if specified, login is disallowed for user names that match one of the patterns.
+ssh_deny_users: ''      # sshd
+
+# if specified, login is allowed only for user names that match one of the patterns.
+ssh_allow_users: ''      # sshd
+
+# if specified, login is disallowed for users whose primary group or supplementary group list matches one of the patterns.
+ssh_deny_groups: ''      # sshd
+
+# if specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns.
+ssh_allow_groups: ''      # sshd
+
+# false to disable printing of the MOTD
+ssh_print_motd: false      # sshd
+
+# false to disable display of last login information
+ssh_print_last_log: false    # sshd

--- a/roles/ansible-ssh-hardening/vars/main.yml
+++ b/roles/ansible-ssh-hardening/vars/main.yml
@@ -1,26 +1,3 @@
-network_ipv6_enable: false              # sshd + ssh
-ssh_client_cbc_required: false          # ssh
-ssh_server_cbc_required: false          # sshd
-ssh_client_weak_hmac: false             # ssh
-ssh_server_weak_hmac: false             # sshd
-ssh_client_weak_kex: false              # ssh
-ssh_server_weak_kex: false              # sshd
-ssh_ports: ['22']      # sshd + ssh
-ssh_listen_to: ['0.0.0.0']    # sshd
-ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key', '/etc/ssh/ssh_host_ecdsa_key']        # sshd
-ssh_client_alive_interval: 600          # sshd
-ssh_client_alive_count: 3               # sshd
-ssh_remote_hosts: []           # ssh
-ssh_allow_root_with_key: false          # sshd
-ssh_allow_tcp_forwarding: false         # sshd
-ssh_allow_agent_forwarding: false       # sshd
-ssh_use_pam: false      # sshd
-ssh_deny_users: ''      # sshd
-ssh_allow_users: ''      # sshd
-ssh_deny_groups: ''      # sshd
-ssh_allow_groups: ''      # sshd
-ssh_print_motd: false      # sshd
-ssh_print_last_log: false    # sshd
 ssh_ps53: 'yes'
 ssh_ps59: 'sandbox'
 


### PR DESCRIPTION
This change moves variables that can be changed or overridden by the user to the defaults-vars-files, where it belongs.

Also added inline documentation.