### PR TITLE
Separate ssh client and server ports. Fix #33

### DIFF
--- a/roles/ansible-ssh-hardening/defaults/main.yml
+++ b/roles/ansible-ssh-hardening/defaults/main.yml
@@ -20,8 +20,11 @@ ssh_server_weak_kex: false              # sshd
 # If true, password login is allowed. For sshd, it is always set to no password login.
 ssh_client_password_login: false          # ssh
 
-# ports to which ssh-server should listen to and ssh-client should connect to
-ssh_ports: ['22']      # sshd + ssh
+# ports to which ssh-server should listen to
+ssh_server_ports: ['22']      # sshd
+
+# ports to which ssh-client should connect to
+ssh_client_ports: ['22']      # ssh
 
 # one or more ip addresses, to which ssh-server should listen to. Default is empty, but should be configured for security reasons!
 ssh_listen_to: ['0.0.0.0']    # sshd

--- a/roles/ansible-ssh-hardening/templates/openssh.conf.j2
+++ b/roles/ansible-ssh-hardening/templates/openssh.conf.j2
@@ -16,7 +16,7 @@ Host {{host}}
 {% endfor %}
 
 # The port at the destination should be defined
-{% for port in ssh_ports -%}
+{% for port in ssh_client_ports -%}
 Port {{port}}
 {% endfor %}
 

--- a/roles/ansible-ssh-hardening/templates/opensshd.conf.j2
+++ b/roles/ansible-ssh-hardening/templates/opensshd.conf.j2
@@ -12,7 +12,7 @@
 PermitRootLogin {{ 'without-password' if ssh_allow_root_with_key else 'no' }}
 
 # Define which port sshd should listen to. Default to `22`.
-{% for port in ssh_ports -%}
+{% for port in ssh_server_ports -%}
 Port {{port}}
 {% endfor %}
 


### PR DESCRIPTION
This PR separates the ssh_ports variable into two separate
variables for the ssh-client and ssh-server.