### PR TITLE
Support for selinux and pam. fix #23

### DIFF
--- a/roles/ansible-ssh-hardening/files/ssh_password
+++ b/roles/ansible-ssh-hardening/files/ssh_password
@@ -1,0 +1,10 @@
+module ssh_password 1.0;
+
+require {
+     type sshd_t;
+     type shadow_t;
+     class file { read open };
+}
+
+#============= sshd_t ==============
+allow sshd_t shadow_t:file { read open };

--- a/roles/ansible-ssh-hardening/tasks/main.yml
+++ b/roles/ansible-ssh-hardening/tasks/main.yml
@@ -39,19 +39,19 @@
 - name: Distributing custom selinux policies
   copy: src='ssh_password' dest='{{ custom_selinux_dir }}'
   register: custom_policies_output
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
 
 - name: check and compile policy
   shell: checkmodule -M -m -o {{ custom_selinux_dir }}/ssh_password.mod {{ custom_selinux_dir }}/ssh_password
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
 
 - name: create selinux policy module package
   shell: semodule_package -o {{ custom_selinux_dir }}/ssh_password.pp  -m {{ custom_selinux_dir }}/ssh_password.mod
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
 
 - name: install selinux policy
   shell: semodule -i {{ custom_selinux_dir }}/ssh_password.pp
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
 
 - name: remove selinux-policy when Pam is used, because Allowing sshd to read the shadow file directly is considered a potential security risk (http://danwalsh.livejournal.com/12333.html)
   shell: semodule -r ssh_password

--- a/roles/ansible-ssh-hardening/tasks/main.yml
+++ b/roles/ansible-ssh-hardening/tasks/main.yml
@@ -55,4 +55,4 @@
 
 - name: remove selinux-policy when Pam is used, because Allowing sshd to read the shadow file directly is considered a potential security risk (http://danwalsh.livejournal.com/12333.html)
   shell: semodule -r ssh_password
-  when: selinux_policy_state.stdout != 'Disabled' and ssh_use_pam
+  when: (selinux_installed.rc == 0) and ssh_use_pam

--- a/roles/ansible-ssh-hardening/tasks/main.yml
+++ b/roles/ansible-ssh-hardening/tasks/main.yml
@@ -2,6 +2,17 @@
 - name: add the OS specific variables
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: test to see if selinux is running
+  command: getenforce
+  register: sestatus
+  changed_when: false
+
+- name: check the ssh_password policy state
+  shell: semodule -l | grep "ssh_password" | awk '{print $3}' 
+  register: selinux_policy_state
+  when: sestatus.stdout == 'Enforcing'
+  changed_when: false
+
 - name: create sshd_config and set permissions to root/600
   template: src='opensshd.conf.j2' dest='/etc/ssh/sshd_config' mode=0600 owner=root group=root validate="/usr/sbin/sshd -T -f %s"
   notify: restart sshd
@@ -10,3 +21,31 @@
 - name: create ssh_config and set permissions to root/644
   template: src='openssh.conf.j2' dest='/etc/ssh/ssh_config' mode=0644 owner=root group=root
   when: ssh_client_hardening
+
+- name: Create selinux custom policy drop folder
+  file: path={{ custom_selinux_dir }} state=directory owner=root group=root mode=0750
+  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+
+# The following tasks only get executed when selinux is in state enforcing and UsePam is "no".
+# See this issue for more info: https://github.com/hardening-io/ansible-ssh-hardening/issues/23
+
+- name: Distributing custom selinux policies
+  copy: src='ssh_password' dest='{{ custom_selinux_dir }}'
+  register: custom_policies_output
+  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+
+- name: check and compile policy
+  shell: checkmodule -M -m -o {{ custom_selinux_dir }}/ssh_password.mod {{ custom_selinux_dir }}/ssh_password
+  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+
+- name: create selinux policy module package
+  shell: semodule_package -o {{ custom_selinux_dir }}/ssh_password.pp  -m {{ custom_selinux_dir }}/ssh_password.mod
+  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+
+- name: install selinux policy
+  shell: semodule -i {{ custom_selinux_dir }}/ssh_password.pp
+  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+
+- name: remove selinux-policy when Pam is used, because Allowing sshd to read the shadow file directly is considered a potential security risk (http://danwalsh.livejournal.com/12333.html)
+  shell: semodule -r ssh_password
+  when: selinux_policy_state.stdout != 'Disabled' and ssh_use_pam

--- a/roles/ansible-ssh-hardening/tasks/main.yml
+++ b/roles/ansible-ssh-hardening/tasks/main.yml
@@ -2,22 +2,16 @@
 - name: add the OS specific variables
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: check is selinux is installed
-  command: getenforce
-  register: selinux_installed
-  ignore_errors: true
-  changed_when: false
-
 - name: test to see if selinux is running
   command: getenforce
   register: sestatus
   changed_when: false
-  when: selinux_installed.rc == 0
+  ignore_errors: true
 
 - name: check the ssh_password policy state
   shell: semodule -l | grep "ssh_password" | awk '{print $3}' 
   register: selinux_policy_state
-  when: selinux_installed.rc == 0
+  when: sestatus.rc == 0 and sestatus.stdout != 'Disabled'
   changed_when: false
 
 - name: create sshd_config and set permissions to root/600
@@ -31,7 +25,7 @@
 
 - name: Create selinux custom policy drop folder
   file: path={{ custom_selinux_dir }} state=directory owner=root group=root mode=0750
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
+  when: not ssh_use_pam and sestatus.rc == 0 and sestatus.stdout != 'Disabled'
 
 # The following tasks only get executed when selinux is in state enforcing and UsePam is "no".
 # See this issue for more info: https://github.com/hardening-io/ansible-ssh-hardening/issues/23
@@ -39,20 +33,20 @@
 - name: Distributing custom selinux policies
   copy: src='ssh_password' dest='{{ custom_selinux_dir }}'
   register: custom_policies_output
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
+  when: not ssh_use_pam and sestatus.rc == 0 and sestatus.stdout != 'Disabled'
 
 - name: check and compile policy
   shell: checkmodule -M -m -o {{ custom_selinux_dir }}/ssh_password.mod {{ custom_selinux_dir }}/ssh_password
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
+  when: not ssh_use_pam and sestatus.rc == 0 and sestatus.stdout != 'Disabled'
 
 - name: create selinux policy module package
   shell: semodule_package -o {{ custom_selinux_dir }}/ssh_password.pp  -m {{ custom_selinux_dir }}/ssh_password.mod
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
+  when: not ssh_use_pam and sestatus.rc == 0 and sestatus.stdout != 'Disabled'
 
 - name: install selinux policy
   shell: semodule -i {{ custom_selinux_dir }}/ssh_password.pp
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
+  when: not ssh_use_pam and sestatus.rc == 0 and sestatus.stdout != 'Disabled'
 
 - name: remove selinux-policy when Pam is used, because Allowing sshd to read the shadow file directly is considered a potential security risk (http://danwalsh.livejournal.com/12333.html)
   shell: semodule -r ssh_password
-  when: (selinux_installed.rc == 0) and ssh_use_pam
+  when: sestatus.rc == 0 and ssh_use_pam

--- a/roles/ansible-ssh-hardening/tasks/main.yml
+++ b/roles/ansible-ssh-hardening/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: Create selinux custom policy drop folder
   file: path={{ custom_selinux_dir }} state=directory owner=root group=root mode=0750
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and selinux_installed.rc == 0
 
 # The following tasks only get executed when selinux is in state enforcing and UsePam is "no".
 # See this issue for more info: https://github.com/hardening-io/ansible-ssh-hardening/issues/23

--- a/roles/ansible-ssh-hardening/tasks/main.yml
+++ b/roles/ansible-ssh-hardening/tasks/main.yml
@@ -2,15 +2,22 @@
 - name: add the OS specific variables
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: check is selinux is installed
+  command: getenforce
+  register: selinux_installed
+  ignore_errors: true
+  changed_when: false
+
 - name: test to see if selinux is running
   command: getenforce
   register: sestatus
   changed_when: false
+  when: selinux_installed.rc == 0
 
 - name: check the ssh_password policy state
   shell: semodule -l | grep "ssh_password" | awk '{print $3}' 
   register: selinux_policy_state
-  when: sestatus.stdout == 'Enforcing'
+  when: selinux_installed.rc == 0
   changed_when: false
 
 - name: create sshd_config and set permissions to root/600
@@ -24,7 +31,7 @@
 
 - name: Create selinux custom policy drop folder
   file: path={{ custom_selinux_dir }} state=directory owner=root group=root mode=0750
-  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
 
 # The following tasks only get executed when selinux is in state enforcing and UsePam is "no".
 # See this issue for more info: https://github.com/hardening-io/ansible-ssh-hardening/issues/23
@@ -32,19 +39,19 @@
 - name: Distributing custom selinux policies
   copy: src='ssh_password' dest='{{ custom_selinux_dir }}'
   register: custom_policies_output
-  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
 
 - name: check and compile policy
   shell: checkmodule -M -m -o {{ custom_selinux_dir }}/ssh_password.mod {{ custom_selinux_dir }}/ssh_password
-  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
 
 - name: create selinux policy module package
   shell: semodule_package -o {{ custom_selinux_dir }}/ssh_password.pp  -m {{ custom_selinux_dir }}/ssh_password.mod
-  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
 
 - name: install selinux policy
   shell: semodule -i {{ custom_selinux_dir }}/ssh_password.pp
-  when: not ssh_use_pam and sestatus.stdout == 'Enforcing'
+  when: not ssh_use_pam and sestatus.stdout != 'Disabled'
 
 - name: remove selinux-policy when Pam is used, because Allowing sshd to read the shadow file directly is considered a potential security risk (http://danwalsh.livejournal.com/12333.html)
   shell: semodule -r ssh_password

--- a/roles/ansible-ssh-hardening/vars/main.yml
+++ b/roles/ansible-ssh-hardening/vars/main.yml
@@ -18,3 +18,5 @@ kex_59_weak: '{{kex_59_default + ",diffie-hellman-group14-sha1,diffie-hellman-gr
 kex_66_default: 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
 kex_66_weak: '{{kex_66_default + ",diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1"}}'
 
+# directory where to store ssh_password policy
+custom_selinux_dir: '/etc/selinux/local-policies'


### PR DESCRIPTION
This change add the following:

- it checks wether selinux is in "Enforcing" mode
- when selinux is enforcing, it copies a new selinux-policy to the host
- this policy allows sshd to read the shadow-file directly, which is forbidden by selinux otherwise
- the policy is then compiled, a package is created and the policy is installed
- when selinux is enforcing, pam is used and the policy is not disabled, it gets removed,
  because its considered a security risk. see here: http://danwalsh.livejournal.com/12333.html