### PR TITLE
Allow whitelisted groups on ssh

### DIFF
--- a/roles/ansible-ssh-hardening/templates/opensshd.conf.j2
+++ b/roles/ansible-ssh-hardening/templates/opensshd.conf.j2
@@ -164,7 +164,7 @@ AllowUsers {{ssh_allow_users}}
 DenyGroups {{ssh_deny_groups}}
 {% endif %}
 
-{% if ssh_deny_groups -%}
+{% if ssh_allow_groups -%}
 AllowGroups {{ssh_allow_groups}}
 {% endif %}
 


### PR DESCRIPTION
Setting ``ssh_allow_groups`` does not work when set since the corresponding if-check tests for the wrong variable