### PR TITLE
Added sftp_enabled, sftp_chroot_dir, and ssh_client_roaming from the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ This role provides secure ssh-client and ssh-server configurations.
 * ``ssh_allow_groups: ''`` - if specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns.
 * ``ssh_print_motd`` - false to disable printing of the MOTD
 * ``ssh_print_last_log`` - false to disable display of last login information
-
+* ``sftp_enabled`` - true to enable sftp configuration
+* ``sftp_chroot_dir`` - change default sftp chroot location
+* ``ssh_client_roaming`` - enable experimental client roaming
 
 ## Example Playbook
 


### PR DESCRIPTION
…defaults

Sftp will get disabled by default. Some people might miss this at a glance, and
some ansible module will not work without sftp. 
`scp_if_ssh = True` needs to can set in ansible.cfg to get around this. 
However, there's currently a bug in ansible 2.0.1.0 that ignores the parameter.

https://github.com/hardening-io/ansible-ssh-hardening/issues/55